### PR TITLE
Refactor: Rename composite components for consistency

### DIFF
--- a/src/base/composites/AttributeClassComposite.ts
+++ b/src/base/composites/AttributeClassComposite.ts
@@ -1,5 +1,5 @@
 /**
- * AttributeClassComponent - Component with attribute management and utility class generation
+ * AttributeClassComposite - Component with attribute management and utility class generation
  * For components that need both attribute handling and CSS class-based styling
  */
 
@@ -18,7 +18,7 @@ const AttributeClassBase = compose(
   UpdateManagerMixin
 );
 
-export abstract class AttributeClassComponent extends AttributeClassBase {
+export abstract class AttributeClassComposite extends AttributeClassBase {
   constructor(config: ComponentConfig) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     super(config);

--- a/src/base/composites/AttributeComposite.ts
+++ b/src/base/composites/AttributeComposite.ts
@@ -1,8 +1,8 @@
 /**
- * AttributeComponent - Component with attribute management and updates only
+ * AttributeComposite - Component with attribute management and updates only
  * For components that need attribute handling but NOT utility class generation
  *
- * Use AttributeClassComponent if you need utility class generation.
+ * Use AttributeClassComposite if you need utility class generation.
  */
 
 import { CoreCustomElement } from '../CoreCustomElement.js';
@@ -14,7 +14,7 @@ import type { ComponentConfig } from '../../types/component.js';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const AttributeBase = compose(CoreCustomElement, AttributeManagerMixin, UpdateManagerMixin);
 
-export abstract class AttributeComponent extends AttributeBase {
+export abstract class AttributeComposite extends AttributeBase {
   constructor(config: ComponentConfig) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     super(config);

--- a/src/base/composites/FullComposite.ts
+++ b/src/base/composites/FullComposite.ts
@@ -1,5 +1,5 @@
 /**
- * FullComponent - Complete component with all mixins
+ * FullComposite - Complete component with all mixins
  * Equivalent to the current BaseComponent but built with mixins
  */
 
@@ -29,7 +29,7 @@ const FullBase = compose(
   UpdateManagerMixin
 );
 
-export abstract class FullComponent extends FullBase implements ShadowDOMMixinInterface {
+export abstract class FullComposite extends FullBase implements ShadowDOMMixinInterface {
   // Declare properties from ShadowDOMMixin
   declare shadowRoot: ShadowRoot | null;
   declare shadowDOMCreated: boolean;

--- a/src/base/composites/InteractiveAttributeComposite.ts
+++ b/src/base/composites/InteractiveAttributeComposite.ts
@@ -1,5 +1,5 @@
 /**
- * InteractiveAttributeComponent - Component with accessibility, attributes, events, and updates
+ * InteractiveAttributeComposite - Component with accessibility, attributes, events, and updates
  * For interactive elements that need sophisticated attribute handling
  */
 
@@ -20,7 +20,7 @@ const InteractiveAttributeBase = compose(
   UpdateManagerMixin
 );
 
-export abstract class InteractiveAttributeComponent extends InteractiveAttributeBase {
+export abstract class InteractiveAttributeComposite extends InteractiveAttributeBase {
   constructor(config: ComponentConfig) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     super(config);

--- a/src/base/composites/InteractiveComposite.ts
+++ b/src/base/composites/InteractiveComposite.ts
@@ -1,5 +1,5 @@
 /**
- * InteractiveComponent - Component with accessibility, events, and updates
+ * InteractiveComposite - Component with accessibility, events, and updates
  * For interactive elements like buttons that don't need attribute management
  */
 
@@ -19,7 +19,7 @@ const InteractiveBase = compose(
   UpdateManagerMixin
 );
 
-export abstract class InteractiveComponent
+export abstract class InteractiveComposite
   extends InteractiveBase
   implements UpdateManagerMixinInterface
 {

--- a/src/base/composites/ShadowComposite.ts
+++ b/src/base/composites/ShadowComposite.ts
@@ -1,5 +1,5 @@
 /**
- * ShadowComponent - Component with Shadow DOM, styles, and updates
+ * ShadowComposite - Component with Shadow DOM, styles, and updates
  * For components that need Shadow DOM encapsulation
  */
 
@@ -22,7 +22,7 @@ const ShadowBase = compose(
   UpdateManagerMixin
 );
 
-export abstract class ShadowComponent
+export abstract class ShadowComposite
   extends ShadowBase
   implements ShadowDOMMixinInterface, UpdateManagerMixinInterface
 {

--- a/src/base/composites/SimpleComposite.ts
+++ b/src/base/composites/SimpleComposite.ts
@@ -1,12 +1,12 @@
 /**
- * SimpleComponent - Minimal component for display-only elements
+ * SimpleComposite - Minimal component for display-only elements
  * Uses only CoreCustomElement without any mixins
  */
 
 import { CoreCustomElement } from '../CoreCustomElement.js';
 import type { ComponentConfig } from '../../types/component.js';
 
-export abstract class SimpleComponent extends CoreCustomElement {
+export abstract class SimpleComposite extends CoreCustomElement {
   constructor(config: ComponentConfig) {
     super(config);
   }

--- a/src/base/composites/index.ts
+++ b/src/base/composites/index.ts
@@ -2,9 +2,10 @@
  * Composite component exports - Pre-composed base classes
  */
 
-export { SimpleComponent } from './SimpleComponent.js';
-export { InteractiveComponent } from './InteractiveComponent.js';
-export { AttributeComponent } from './AttributeComponent.js';
-export { InteractiveAttributeComponent } from './InteractiveAttributeComponent.js';
-export { ShadowComponent } from './ShadowComponent.js';
-export { FullComponent } from './FullComponent.js';
+export { SimpleComposite } from './SimpleComposite.js';
+export { InteractiveComposite } from './InteractiveComposite.js';
+export { AttributeComposite } from './AttributeComposite.js';
+export { AttributeClassComposite } from './AttributeClassComposite.js';
+export { InteractiveAttributeComposite } from './InteractiveAttributeComposite.js';
+export { ShadowComposite } from './ShadowComposite.js';
+export { FullComposite } from './FullComposite.js';


### PR DESCRIPTION
## Summary
- Rename all composite component files from `*Component.ts` to `*Composite.ts`
- Update class names and JSDoc comments consistently across all composites
- Update exports in `composites/index.ts` to reflect new naming
- Resolves critical naming conflict between deprecated `ShadowComponent` and composite `ShadowComponent`

## Changes Made
- **File Renames**: All 7 composite files renamed for consistency
- **Class Names**: Updated all exported class names to use `*Composite` pattern
- **Documentation**: Updated JSDoc comments and cross-references
- **Exports**: Updated `index.ts` to export new composite names

## Architectural Issues Resolved
- **Issue #1**: ShadowComponent naming conflict (Critical)
- **Issue #3**: Composite component naming inconsistency (High)

## Test Plan
- [x] All tests passing (`pnpm test:run`)
- [x] Build successful (`pnpm build`)
- [x] TypeScript compilation clean
- [x] No import conflicts found in codebase

## Verification
- **Before**: Multiple `*Component` classes causing confusion
- **After**: Clear `*Composite` naming that distinguishes pre-composed base classes
- **Impact**: Developers can now clearly differentiate between individual components and composite base classes

🤖 Generated with [Claude Code](https://claude.ai/code)